### PR TITLE
Adopt TWAMP reflector to use in automation testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ client:
 	$(CC) -o $(PROGRAM2) $(SRC2) $(SRCS) $(CCFLAGS)
 
 setcap:
-	sudo setcap 'cap_net_bind_service=+ep' ./server
+	setcap 'cap_net_bind_service=+ep' ./server
 
 runserver:
 	./server

--- a/client.c
+++ b/client.c
@@ -158,12 +158,6 @@ int main(int argc, char *argv[])
     struct sockaddr_in serv_addr;
     struct hostent *server = NULL;
 
-    /* Sanity check */
-    if (getuid() == 0) {
-        fprintf(stderr, "%s should not be run as root\n", progname);
-        exit(EXIT_FAILURE);
-    }
-
     /* Check client options */
     if (parse_options(&server, progname, argc, argv)) {
         usage(progname);


### PR DESCRIPTION
Update server.c:
    - Add command line argument '-P' for specifying TWAMP control port
    - Update mechanism of TWAMP test port usage - now concrete port is used (not random)
    - Update command line argument '-p'. Now it means concrete test port (not minimal boundary)
